### PR TITLE
Add error boundary

### DIFF
--- a/src/guillo-gmi/components/error_boundary.js
+++ b/src/guillo-gmi/components/error_boundary.js
@@ -1,0 +1,31 @@
+import React from 'react'
+
+const style = { color: '#F44336', fontSize: 20, paddingBottom: 20 }
+
+export default class ErrorBoundary extends React.Component {
+  state = {}
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ 
+      hasError: true, 
+      errorMsg: error.message,
+      errorStack: errorInfo.componentStack
+    })
+  }
+
+  render() {
+    const { hasError, errorMsg, errorStack } = this.state
+
+    if (hasError) {
+      return (
+        <div className="box main-panel">
+          <div style={style}>Something went wrong.</div>
+          {errorMsg && <p><b>{errorMsg}</b></p>}
+          {errorStack && <p>{errorStack}</p>}
+        </div>
+      );
+    }
+
+    return this.props.children; 
+  }
+}

--- a/src/guillo-gmi/components/guillotina.js
+++ b/src/guillo-gmi/components/guillotina.js
@@ -15,6 +15,7 @@ import { useLocation } from "../hooks/useLocation";
 import { guillotinaReducer } from "../reducers/guillotina";
 import { initialState } from "../reducers/guillotina";
 import { Loading } from './ui/loading'
+import ErrorBoundary from "./error_boundary";
 
 export function Guillotina({ auth, ...props }) {
   const url = props.url || "http://localhost:8080"; // without trailing slash
@@ -83,7 +84,7 @@ export function Guillotina({ auth, ...props }) {
   const Action = action.action ? registry.getAction(action.action) : null;
 
   return (
-    <React.Fragment>
+    <ErrorBoundary>
       {!errorStatus && (
         <TraversalProvider {...contextData}>
           {permissions && (
@@ -98,10 +99,12 @@ export function Guillotina({ auth, ...props }) {
               </div>
               <Flash />
               {Main && (
-                <div className="box main-panel">
-                  {state.loading && <Loading />}
-                  {!state.loading && <Main state={state} />}
-                </div>
+                <ErrorBoundary>
+                  <div className="box main-panel">
+                    {state.loading && <Loading />}
+                    {!state.loading && <Main state={state} />}
+                  </div>
+                </ErrorBoundary>
               )}
               {/* <p>Guillotina {JSON.stringify(state.context)}</p> */}
             </React.Fragment>
@@ -110,6 +113,6 @@ export function Guillotina({ auth, ...props }) {
       )}
       {errorStatus === "notallowed" && <NotAllowed />}
       {errorStatus === "notfound" && <NotFound />}
-    </React.Fragment>
+    </ErrorBoundary>
   );
 }


### PR DESCRIPTION
Fixes https://github.com/guillotinaweb/guillotina_react/issues/11

I added the ErrorBoundary in two places: on top of Main + on the top of all the Guillotina component tree.

Message composed by error message + component error stack

![image](https://user-images.githubusercontent.com/13313058/73456586-6e0e8700-4372-11ea-970e-e2d2b0772f8f.png)
