### PR TITLE
Scroll to top after Ctx.flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.3
+----
+- Scroll to top after call to Ctx.flash
+
 0.4.2
 ----
 - fix bug on behaviors change

--- a/src/guillo-gmi/contexts/index.js
+++ b/src/guillo-gmi/contexts/index.js
@@ -44,6 +44,7 @@ class Traversal {
 
   flash(message, type) {
     this.dispatch({ type: "SET_FLASH", payload: { flash: { message, type } } });
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
   }
 
   clearFlash() {


### PR DESCRIPTION
https://github.com/vinissimus/product/issues/2693

Although we implement a Toast in the future, if we want to maintain the "flash", it would be useful if it's scrolled to the top after displaying the flash message.