### PR TITLE
Fix duplicate items in same folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.6
+----
+- Fix duplicate items in same folder (add a suffix to the id)
+
 0.4.5
 ----
 - Fix TabsPanel crash when 'current' tab doesn't exist in 'tabs'

--- a/src/guillo-gmi/actions/copy_items.js
+++ b/src/guillo-gmi/actions/copy_items.js
@@ -5,6 +5,16 @@ import {TraversalContext} from '../contexts'
 
 const withError = res => res.status >= 300
 
+function getNewId(id = '') {
+  const suffix = '-copy-'
+  const rgx = new RegExp(`($|${suffix}\\d*)`)
+
+  return id.replace(rgx, r => { 
+    const num = parseInt(r.replace(suffix, '') || '0')
+    return `${suffix}${num + 1}`
+  })
+}
+
 export function CopyItems(props) {
   const Ctx = useContext(TraversalContext)
   const { items = [] } = props
@@ -13,7 +23,7 @@ export function CopyItems(props) {
     const responses = await Promise.all(items.map(item => {
       return Ctx.client.post(`${Ctx.path}${item['@name']}/@duplicate`, {
         destination: path,
-        new_id: item['@name']
+        new_id: getNewId(item.id)
       });
     }))
 


### PR DESCRIPTION
Closes https://github.com/vinissimus/product/issues/3573 reported by @carme-carrillo

Until now, when an item was duplicated in the same folder, an error was thrown because the id was duplicated. With this small change, the new duplicated item will always have a different id from the copied id.

![image](https://user-images.githubusercontent.com/13313058/94272203-04676c80-ff43-11ea-9886-1c379f35e773.png)

I tested in our admin, with this change in guillotina_react, and it works fine now:

![image](https://user-images.githubusercontent.com/13313058/94272487-6b852100-ff43-11ea-9dfc-19e494a7efc8.png)



