### PR TITLE
Improve copying items experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.4.8
+----
+- Allow modify id copying items [aralroca]
+- Fill current path as default path when copying items [aralroca]
+
 0.4.7
 ----
 - Move column definition to GuillotinaClient to overwrite in an easier way [aralroca]

--- a/src/guillo-gmi/actions/copy_items.js
+++ b/src/guillo-gmi/actions/copy_items.js
@@ -1,7 +1,7 @@
 import React from 'react'
-import {PathTree} from '../components/modal'
-import {useContext} from 'react'
-import {TraversalContext} from '../contexts'
+import { PathTree } from '../components/modal'
+import { useContext } from 'react'
+import { TraversalContext } from '../contexts'
 
 const withError = res => res.status >= 300
 
@@ -9,7 +9,7 @@ function getNewId(id = '') {
   const suffix = '-copy-'
   const rgx = new RegExp(`($|${suffix}\\d*)`)
 
-  return id.replace(rgx, r => { 
+  return id.replace(rgx, r => {
     const num = parseInt(r.replace(suffix, '') || '0')
     return `${suffix}${num + 1}`
   })
@@ -19,23 +19,24 @@ export function CopyItems(props) {
   const Ctx = useContext(TraversalContext)
   const { items = [] } = props
 
-  async function copyItems(path) {   
-    const responses = await Promise.all(items.map(item => {
+  async function copyItems(path, form) {
+    const responses = await Promise.all(items.map((item, i) => {
+      const input = form[i + 1] || {}
       return Ctx.client.post(`${Ctx.path}${item['@name']}/@duplicate`, {
         destination: path,
-        new_id: getNewId(item.id)
+        new_id: input.value || getNewId(item.id)
       });
     }))
 
     Ctx.refresh()
     Ctx.cancelAction()
 
-    if(responses.every(withError)) {
+    if (responses.every(withError)) {
       Ctx.flash(`Oops! Items can't be copied to ${path}`, 'danger')
       return
     }
 
-    if(responses.some(withError)) {
+    if (responses.some(withError)) {
       Ctx.flash(`Some items are not copied correctly!`, 'warning')
       return
     }
@@ -46,8 +47,19 @@ export function CopyItems(props) {
   return (
     <PathTree
       title="Copy to..."
+      defaultPath={Ctx.path}
       onConfirm={copyItems}
       onCancel={() => Ctx.cancelAction()}
-    />
+    >
+      {items.map(item => (
+        <React.Fragment key={item.id}>
+          <small style={{ display: 'block', marginTop: 20 }}>
+            {`New id for "${item.id}" copy`}
+          </small>
+          <input type="text" className="input" defaultValue={getNewId(item.id)} />
+        </React.Fragment>
+      ))}
+      &nbsp;
+    </PathTree>
   )
 }

--- a/src/guillo-gmi/components/modal.js
+++ b/src/guillo-gmi/components/modal.js
@@ -50,20 +50,22 @@ export function Confirm({ message, onCancel, onConfirm, loading }) {
 }
 
 // @todo Improve it... Replacing the inputText to a tree
-export function PathTree({ title, onConfirm, onCancel }){
+export function PathTree({ title, defaultPath, children, onConfirm, onCancel }){
   return (
     <Modal isActive setActive={onCancel}>
       <h1>{title}</h1>
       <form onSubmit={e => {
           e.preventDefault()
-          onConfirm(e.target[0].value)
+          onConfirm(e.target[0].value, e.target)
       }}>
         <input
           className="input"
           placeholder="/folder (without /db/container on front)"
           style={{ margin: '20px 0'}}
+          defaultValue={defaultPath}
           type="text"
         />
+        {children}
         <div className="level-right">
           <button type="button" className="button is-danger" onClick={onCancel}>
             Cancel


### PR DESCRIPTION
Closes https://github.com/vinissimus/product/issues/3588

reported by @carme-carrillo here https://github.com/vinissimus/product/issues/3588

Basically I have made two improvements when copying items:

1. Optionally, you can modify the new id. *(By default, it puts the `-copy-n` at the end of the old id, but it can be changed manually by the user)*.

2. The `path` field, by default, now is filled by the current path, since most times it will be copied in the same directory.



![image](https://user-images.githubusercontent.com/13313058/94845611-39caf900-0420-11eb-9b8e-b59619cf96b6.png)
