### PR TITLE
Add pagination also in the bottom of the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.9
+----
+- Add pagination also in the bottom of the page [aralroca]
+
 0.4.8
 ----
 - Allow modify id copying items [aralroca]

--- a/src/guillo-gmi/components/panel/items.js
+++ b/src/guillo-gmi/components/panel/items.js
@@ -21,7 +21,7 @@ const initialState = {
 
 export function PanelItems(props) {
   const [location, setLocation] = useLocation();
-  const {PageSize} = useConfig()
+  const { PageSize } = useConfig()
 
   const Ctx = useContext(TraversalContext);
   const [state, setState] = useSetState(initialState);
@@ -43,7 +43,7 @@ export function PanelItems(props) {
   }
 
   useEffect(() => {
-    if(Ctx.state.loading) return
+    if (Ctx.state.loading) return
     (async () => {
       let data;
       setState({ loading: true, total: Ctx.context.length });
@@ -87,6 +87,7 @@ export function PanelItems(props) {
           <Pagination
             current={page}
             total={total}
+            key="pagination-top"
             doPaginate={doPaginate}
             pager={PageSize}
           />
@@ -112,7 +113,7 @@ export function PanelItems(props) {
                   key={item["@uid"]}
                   search={search}
                   columns={columns}
-                  />
+                />
               ))}
             {items && items.length === 0 && (
               <tr>
@@ -124,6 +125,15 @@ export function PanelItems(props) {
           </tbody>
         </table>
       )}
+      <div className="columns is-centered">
+        <Pagination
+          current={page}
+          key="pagination-bottom"
+          total={total}
+          doPaginate={doPaginate}
+          pager={PageSize}
+        />
+      </div>
     </ItemsActionsProvider>
   );
 }


### PR DESCRIPTION
Closes https://github.com/guillotinaweb/guillotina_react/issues/60

I have duplicated the pagination component, now it comes out both at the top and at the bottom of the list.

![image](https://user-images.githubusercontent.com/13313058/95062467-4a6bbf80-06fd-11eb-811a-770fd83880ef.png)
