### PR TITLE
Fix open breadcrumb links in a new browser tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.10
+----
+- Fix open breadcrumb links in a new browser tab [aralroca]
+
 0.4.9
 ----
 - Add pagination also in the bottom of the page [aralroca]

--- a/src/guillo-gmi/components/path.js
+++ b/src/guillo-gmi/components/path.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 import {TraversalContext} from '../contexts'
 import {useContext} from 'react'
 import {useLocation} from '../hooks/useLocation'
@@ -23,10 +23,10 @@ export function Path(props) {
       {segments.map((item, indx) => {
           const path = links[indx]
           const onClick = (e) => {
-            if (window.event.ctrlKey || window.event.metaKey) return;
-            e.preventDefault();
-            navigate({ path }, true);
-          };
+            if (window.event.ctrlKey || window.event.metaKey) return
+            e.preventDefault()
+            navigate({ path }, true)
+          }
 
           return indx === 0 ? (
             <li key={indx}>
@@ -42,7 +42,7 @@ export function Path(props) {
                 {item}
               </a>
             </li>
-          );
+          )
         })}
       </ul>
     </nav>

--- a/src/guillo-gmi/components/path.js
+++ b/src/guillo-gmi/components/path.js
@@ -20,19 +20,30 @@ export function Path(props) {
   return (
     <nav className="breadcrumb" aria-label="breadcrumbs">
       <ul>
-      {segments.map((item, indx) =>
-        ((indx === 0) ?
-          <li key={indx}>
-            <a onClick={() => navigate({path:links[indx]}, true)}>
-              <span className="icon">
-                <i className="fas fa-home"></i>
-              </span>
-            </a>
-          </li>
-          :
-          <li key={indx}><a onClick={() => navigate({path:links[indx]}, true)}>
-          {item}</a></li>
-      ))}
+      {segments.map((item, indx) => {
+          const path = links[indx]
+          const onClick = (e) => {
+            if (window.event.ctrlKey || window.event.metaKey) return;
+            e.preventDefault();
+            navigate({ path }, true);
+          };
+
+          return indx === 0 ? (
+            <li key={indx}>
+              <a href={path} onClick={onClick}>
+                <span className="icon">
+                  <i className="fas fa-home"></i>
+                </span>
+              </a>
+            </li>
+          ) : (
+            <li key={indx}>
+              <a href={path} onClick={onClick}>
+                {item}
+              </a>
+            </li>
+          );
+        })}
       </ul>
     </nav>
   )


### PR DESCRIPTION
Closes https://github.com/vinissimus/product/issues/3635

With this PR it is now possible to open the content of the breadcrumb in another tab, maintaining the same behavior as before when clicking the link. 

