### PR TITLE
Fix issue with React and microbundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.11
+----
+- Fix issue with React and microbundle
+
 0.4.10
 ----
 - Fix open breadcrumb links in a new browser tab [aralroca]

--- a/src/guillo-gmi/components/panel/behaviors.js
+++ b/src/guillo-gmi/components/panel/behaviors.js
@@ -21,11 +21,7 @@ export function PanelBehaviors() {
     Ctx.refresh()
   };
 
-  React.useEffect(() => {
-    (async () => {
-      await get("@behaviors");
-    })();
-  }, []);
+  React.useEffect(() => { get("@behaviors") }, []);
 
   return (
     <div className="columns behaviors">

--- a/src/guillo-gmi/components/panel/permissions.js
+++ b/src/guillo-gmi/components/panel/permissions.js
@@ -15,11 +15,7 @@ export function PanelPermissions(props) {
 
   const [reset, setReset] = React.useState(1);
 
-  React.useEffect(() => {
-    (async () => {
-      await get("@sharing");
-    })();
-  }, [reset]);
+  React.useEffect(() => { get("@sharing") }, [reset]);
 
   const perms = new Sharing(result);
 
@@ -143,7 +139,7 @@ export function AddPermission({ refresh, reset }) {
   const [state, setState] = useSetState(initial);
 
   React.useEffect(() => {
-    (async () => {
+    async function init() {
       const permissions = (await Ctx.client.getAllPermissions(Ctx.path)).map(
         perm => ({
           text: perm,
@@ -161,7 +157,9 @@ export function AddPermission({ refresh, reset }) {
         value: role
       }));
       setState({ permissions, groups, roles });
-    })();
+    };
+
+    init();
   }, [reset]);
 
   return (


### PR DESCRIPTION
**Before:**

![error](https://user-images.githubusercontent.com/13313058/96003814-ed79b300-0e3a-11eb-9cd1-4056faaf763c.gif)

**Now:**

![now](https://user-images.githubusercontent.com/13313058/96003935-10a46280-0e3b-11eb-98da-25a7a21bff99.gif)

**What was happening?**

This code:

```js
React.useEffect(() => {
    (async () => {	
      await get("@behaviors");	
    })();	
  }, []);
```

After microbundle it becomes to:

```js
 React.useEffect(function () {
    try {
      return Promise.resolve(get("@behaviors")).then(function () {});
    } catch (e) {
      Promise.reject(e);
    }
  }, []);
```

As `useEffect` works in (P)React, here the cleanup is a promise... And should be a function! So when the component is unmounted can't unmount well, throwing an error. The issue can be reproduced whenever we leave the Behaviors or Permissions tab.

Changing the content of the `useEffect` to:

```js
React.useEffect(() => { get("@behaviors") }, []);
```

It solves the problem. `get("@behaviors")` returns a promises, but is not necessary to indicate that the function is async because we don't need to await that promise. So now there isn't a wrong cleanup for the unmount event.