### PR TITLE
Allow to add a custom flash function on config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.4.12
+0.6.4
 ------
 - Allow to add a custom flash function on config
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.11
+----
+- Allow to add a custom flash function on config
+
 0.4.10
 ----
 - Fix open breadcrumb links in a new browser tab [aralroca]

--- a/src/guillo-gmi/components/guillotina.js
+++ b/src/guillo-gmi/components/guillotina.js
@@ -18,11 +18,12 @@ import { Loading } from './ui/loading'
 
 export function Guillotina({ auth, ...props }) {
   const url = props.url || "http://localhost:8080"; // without trailing slash
+  const config = props.config || {}
 
   // Will hold client instance
   const ref = useRef();
 
-  useConfig(props.config || {});
+  useConfig(config);
   const registry = useRegistry(props.registry || {});
   // Location is cooked routing solution (only uses search params)
   const [location, setRouterParam] = useLocation();
@@ -76,7 +77,8 @@ export function Guillotina({ auth, ...props }) {
     state,
     dispatch,
     registry,
-    setRouterParam
+    setRouterParam,
+    flash: config.flash
   };
 
   const { action, errorStatus, permissions } = state;

--- a/src/guillo-gmi/contexts/index.js
+++ b/src/guillo-gmi/contexts/index.js
@@ -7,8 +7,9 @@ export const AuthContext = createContext({});
 export const TraversalContext = createContext({});
 
 class Traversal {
-  constructor(props) {
+  constructor({ flash, ...props }) {
     Object.assign(this, props);
+    if(typeof flash === 'function') this.flash = flash;
   }
 
   setPath(path) {


### PR DESCRIPTION
By default, the "flash" still has the same behavior as before. But at the same time, now from the configuration you can modify the behavior.

For example, if we want to use `antd`'s `message`, we could do it with:

```jsx
import { message } from 'antd';

// ...

const supportedMessageType = new Set(['error', 'warning', 'success']);

const config = {
 flash: (msg, type) => {
    if (supportedMessageType.has(type)) return message[type](msg);
    message.error(msg);
  }
  ...restOfConfig,
}

// ...
return (
  <Guillotina
   client={client}
   config={config}
   url={url}
   registry={registry}
  />
)
```

![image](https://user-images.githubusercontent.com/13313058/96334419-0bc8f400-1071-11eb-9146-b877c135b923.png)
