### PR TITLE
Add useTraversal hook and use it in favor of useContext(TraversalContext)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,3 @@
-
 # Guillotina React API
 
 - [Architecture](#architecture)
@@ -33,46 +32,47 @@
   actions on screens. [Read here about traversal context](#traversal-context).
 
 - There is a "component registry" to be able to override components, on
-   installations. Actually it's just some maps where you can register,
-   component overrides
+  installations. Actually it's just some maps where you can register,
+  component overrides
 
-   - registry/
-     Acts as a base context screen registry,
+  - registry/
+    Acts as a base context screen registry,
     `getCompoment() and registerComponent() as API exposed
 
-   - actions/
-     - Actions are mostly UI interactions you trigger from buttons (remove item)
-     and when adding types (Context menu +)
-     - They mostly are based on a "modal" that proposes you something
-     - Actions can be dispatched, using the main Context
+  - actions/
 
-     ```
-     Ctx = useContext(TraversalContext)
-     Ctx.doAction("addItem" , "Folder")
-     ```
+    - Actions are mostly UI interactions you trigger from buttons (remove item)
+      and when adding types (Context menu +)
+    - They mostly are based on a "modal" that proposes you something
+    - Actions can be dispatched, using the main Context
 
-     will show a modal to add an item for a folder
+    ```
+    Ctx = useTraversal()
+    Ctx.doAction("addItem" , "Folder")
+    ```
 
-   - forms/
-     - Used throught actions to provide forms for <Forms>
+    will show a modal to add an item for a folder
 
+  - forms/
+    - Used throught actions to provide forms for <Forms>
 
 views/
-  - Stores views for contexts
+
+- Stores views for contexts
 
 ## Traversal Context
 
 @guillotinaweb/react-gmi mostly uses react.Context and hooks to manage state. Through the traversal context we have access to the Guillotina content and to some UI actions / helpers.
 
 ```jsx
-import { TraversalContext } from '@guillotinaweb/react-gmi'
+import { useTraversal } from '@guillotinaweb/react-gmi'
 // ...
-const Ctx = useContext(TraversalContext)
+const Ctx = useTraversal()
 // ...
-Ctx.setPath('/db/guillotina/')  // will navigate tracersal to the container
+Ctx.setPath('/db/guillotina/') // will navigate tracersal to the container
 Ctx.doAction // show an action
 Ctx.cancelAction // hide (terminate) the latest action. Used, when the process completes
-Ctx.flash  // Show a flash message on the main screen
+Ctx.flash // Show a flash message on the main screen
 Ctx.refresh // Force a refresh from the server for the current traversal context
 // Properties
 Ctx.path // exposes the current context path (without service url)
@@ -94,7 +94,7 @@ Under the hood it uses [wouter](https://github.com/molefrog/wouter).
 import { useLocation } from '@guillotinaweb/react-gmi'
 
 // ...
-  const [location, setLocation] = useLocation();
+const [location, setLocation] = useLocation()
 ```
 
 ## Components
@@ -102,7 +102,11 @@ import { useLocation } from '@guillotinaweb/react-gmi'
 ### Guillotina
 
 ```jsx
-import { Guillotina, GuillotinaClient, RestClient } from "@guillotinaweb/react-gmi"
+import {
+  Guillotina,
+  GuillotinaClient,
+  RestClient,
+} from '@guillotinaweb/react-gmi'
 // ...
 const client = new GuillotinaClient(new RestClient(url, auth))
 // ...
@@ -111,10 +115,10 @@ return (
     client={client}
     config={{
       icons: {
-        Banners: "fas fa-image",
-        Products: "fas fa-wine-glass",
-        Landings: "fas fa-receipt",
-        Newsletter: 'fas fa-envelope'
+        Banners: 'fas fa-image',
+        Products: 'fas fa-wine-glass',
+        Landings: 'fas fa-receipt',
+        Newsletter: 'fas fa-envelope',
       },
       PageSize: 30,
       DelayActions: 2000,
@@ -137,11 +141,10 @@ return (
         Products: {
           Buttons: null,
         },
-      }
+      },
     }}
   />
 )
-
 ```
 
 ### TabsPanel
@@ -149,9 +152,9 @@ return (
 It creates separate tabs, allowing you to add permissions to each tab if used in conjunction with `Ctx.filterTabs`.
 
 ```jsx
-import { TabsPanel } from "@guillotinaweb/react-gmi"
+import { useTraversal, TabsPanel } from '@guillotinaweb/react-gmi'
 // ...
-const Ctx = React.useContext(TraversalContext);
+const Ctx = useTraversal()
 
 return (
   <TabsPanel
@@ -162,12 +165,12 @@ return (
         AuditLog: AuditLogTab,
       },
       {
-        Data: "guillotina.ViewContent",
-        Sections: "guillotina.ModifyContent",
+        Data: 'guillotina.ViewContent',
+        Sections: 'guillotina.ModifyContent',
       }
     )}
     currentTab="Data"
-    editableTabs={["Data"]}
+    editableTabs={['Data']}
     rightToolbar={<ContextToolbar {...props} />}
     {...props}
   />
@@ -179,7 +182,7 @@ return (
 It is the bar where there is a content search engine along with the buttons with the different actions that the page has.
 
 ```jsx
-import { ContextToolbar } from "@guillotinaweb/react-gmi"
+import { ContextToolbar } from '@guillotinaweb/react-gmi'
 // ...
 return <ContextToolbar {...props} />
 ```
@@ -189,9 +192,9 @@ return <ContextToolbar {...props} />
 To be used in conjunction with the TabsPanel we have two ready-to-use panels already created: Permissions + Properties.
 
 ```jsx
-import { PanelPermissions } from "@guillotinaweb/react-gmi"
-import { PanelProperties } from "@guillotinaweb/react-gmi"
-import { PanelItems } from "@guillotinaweb/react-gmi"
+import { PanelPermissions } from '@guillotinaweb/react-gmi'
+import { PanelProperties } from '@guillotinaweb/react-gmi'
+import { PanelItems } from '@guillotinaweb/react-gmi'
 
 // ...
 const tabs = {
@@ -216,17 +219,13 @@ return <Icon icon="fas fa-angle-left" />
 
 ### Modal
 
-You can use the Modal component to put content over everything else in the document. 
+You can use the Modal component to put content over everything else in the document.
 
 ```jsx
-import { Modal } from "@guillotinaweb/react-gmi"
+import { Modal } from '@guillotinaweb/react-gmi'
 // ...
 return (
-  <Modal
-    className="modal-content"
-    isActive={isActive}
-    setActive={close}
-  >
+  <Modal className="modal-content" isActive={isActive} setActive={close}>
     {/* Modal content here */}
   </Modal>
 )
@@ -237,11 +236,11 @@ return (
 Wrapper of the html5 form but already designed to integrate with the form components we provide. Apart from that it has some more extra properties and there is no need to do e.preventDefault during the onSubmit.
 
 ```jsx
-import { Form } from "@guillotinaweb/react-gmi"
+import { Form } from '@guillotinaweb/react-gmi'
 // ...
 return (
   <Form onSubmit={submit} title="My form" error={errorMsg}>
-    {/* all form components here */}   
+    {/* all form components here */}
   </Form>
 )
 ```
@@ -250,14 +249,13 @@ return (
 
 Wrapper of the html5 input-text but already designed to integrate with the rest of the form components.
 
-
 ```jsx
-import { Input } from "@guillotinaweb/react-gmi"
+import { Input } from '@guillotinaweb/react-gmi'
 // ...
 return (
   <Input
     className="is-size-6"
-    onChange={text => setValue(text)}
+    onChange={(text) => setValue(text)}
     placeholder="Example"
     value={value}
   />
@@ -279,14 +277,17 @@ return <Textarea placeholder="Write here" value={text} onChange={onChange} />
 A custom Select component where you can pass the options as a prop.
 
 ```jsx
-import { Select } from "@guillotinaweb/react-gmi"
+import { Select } from '@guillotinaweb/react-gmi'
 // ...
 return (
   <Select
     value={value}
-    options={[{ text: "First", value: "1" }, { text: "Second", value: "2"}]}
+    options={[
+      { text: 'First', value: '1' },
+      { text: 'Second', value: '2' },
+    ]}
     appendDefault
-    onChange={e => setValue(e.target.value)}
+    onChange={(e) => setValue(e.target.value)}
     classWrap="is-small"
   />
 )
@@ -297,7 +298,7 @@ return (
 Wrapper of the html5 checkbox but already designed to integrate with the rest of the form components.
 
 ```jsx
-import { Checkbox } from "@guillotinaweb/react-gmi"
+import { Checkbox } from '@guillotinaweb/react-gmi'
 // ...
 return (
   <Checkbox
@@ -315,7 +316,11 @@ Wrapper of the button of html5 but already thought to integrate with the rest of
 ```jsx
 import { Button } from '@guillotinaweb/react-gmi'
 // ...
-return <Button className="is-warning" loading={loading}>Login</Button>
+return (
+  <Button className="is-warning" loading={loading}>
+    Login
+  </Button>
+)
 ```
 
 #### FileUpload
@@ -333,7 +338,7 @@ return <FileUpload onChange={uploadFile} accept="image/*" />
 Displays a loading bar indicating that the content is loading.
 
 ```jsx
-import { Loading } from "@guillotinaweb/react-gmi"
+import { Loading } from '@guillotinaweb/react-gmi'
 // ...
 return <Loading />
 ```
@@ -347,10 +352,14 @@ Necessary for when we create the GuillotinaClient instance to indicate the url w
 Underneath it uses `fetch`.
 
 ```jsx
-import { GuillotinaClient, RestClient } from "@guillotinaweb/react-gmi"
+import { GuillotinaClient, RestClient } from '@guillotinaweb/react-gmi'
 // ...
-const auth = { getToken: () => {/* ... */} , }
-const restClient = new RestClient("/db/guillotina", auth)
+const auth = {
+  getToken: () => {
+    /* ... */
+  },
+}
+const restClient = new RestClient('/db/guillotina', auth)
 const client = new GuillotinaClient(restClient)
 ```
 
@@ -359,7 +368,7 @@ const client = new GuillotinaClient(restClient)
 Compose CSS classes in a easy way:
 
 ```jsx
-import { classnames } from '@guillotinaweb/react-gmi';
+import { classnames } from '@guillotinaweb/react-gmi'
 // ...
 function Example({ className, children }) {
   return (
@@ -375,21 +384,20 @@ function Example({ className, children }) {
 Useful for creating content ids automatically from text but ensuring that it does not have weird characters.
 
 ```js
-import { stringToSlug } from "@guillotinaweb/react-gmi"
+import { stringToSlug } from '@guillotinaweb/react-gmi'
 // ...
-stringToSlug("This is an example!") // this-is-an-example
+stringToSlug('This is an example!') // this-is-an-example
 ```
 
 ## Guillotina config
 
-
-| Option            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Type                            | Default                                                                         |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------- | ------------------------------------------------------------------------------- | 
-| `icons`   | You can assign a fontawesome icon for each content.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `Object<string>`                        | `{}`                                                                          |
-| `PageSize`         | Elements to display in each page                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `Number`                 | `10`                                                                            |
-| `DelayActions` | Applies a delay after actions such as refresh.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | `Number`                        | `200`                                                                      |
-| `DisabledTypes`   | Disabled types.                                                                                                                                                                                                                                                                                                                                                                                                                                  | `string[]`                        | `["UserManager", "GroupManager"]`                                                                       |
-| `Permissions`   | List of permissions.                                                                                                                                                                                                                                                                                                                                                                                                                                   | `string[]`                        | `["guillotina.AddContent","guillotina.ModifyContent","guillotina.ViewContent","guillotina.DeleteContent","guillotina.AccessContent","guillotina.SeePermissions","guillotina.ChangePermissions","guillotina.MoveContent","guillotina.DuplicateContent","guillotina.ReadConfiguration","guillotina.RegisterConfigurations","guillotina.WriteConfiguration","guillotina.ManageAddons","guillotina.swagger.View"]`                                                                       |
-| `properties_default`     | Default content properties.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | `string[]`                        | `["@id", "@name", "@uid", "title"]`                                                                     |
-| `properties_editable`         | Editable content properties.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `string[]`                       | `["title"]`                                                                         |
-| `flash`  | If defined, allows to customize the flash message.                                                                                                                                                                                                                                                                                                                                                                                                                                     | `function`                      | `undefined`                                                                          |
+| Option                | Description                                         | Type             | Default                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --------------------- | --------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `icons`               | You can assign a fontawesome icon for each content. | `Object<string>` | `{}`                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `PageSize`            | Elements to display in each page                    | `Number`         | `10`                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `DelayActions`        | Applies a delay after actions such as refresh.      | `Number`         | `200`                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `DisabledTypes`       | Disabled types.                                     | `string[]`       | `["UserManager", "GroupManager"]`                                                                                                                                                                                                                                                                                                                                                                              |
+| `Permissions`         | List of permissions.                                | `string[]`       | `["guillotina.AddContent","guillotina.ModifyContent","guillotina.ViewContent","guillotina.DeleteContent","guillotina.AccessContent","guillotina.SeePermissions","guillotina.ChangePermissions","guillotina.MoveContent","guillotina.DuplicateContent","guillotina.ReadConfiguration","guillotina.RegisterConfigurations","guillotina.WriteConfiguration","guillotina.ManageAddons","guillotina.swagger.View"]` |
+| `properties_default`  | Default content properties.                         | `string[]`       | `["@id", "@name", "@uid", "title"]`                                                                                                                                                                                                                                                                                                                                                                            |
+| `properties_editable` | Editable content properties.                        | `string[]`       | `["title"]`                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `flash`               | If defined, allows to customize the flash message.  | `function`       | `undefined`                                                                                                                                                                                                                                                                                                                                                                                                    |

--- a/src/guillo-gmi/actions/add_item.js
+++ b/src/guillo-gmi/actions/add_item.js
@@ -1,10 +1,9 @@
 import React from 'react'
-import { useContext } from 'react'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 import { Modal } from '../components/modal'
 
 export function AddItem(props) {
-  const Ctx = useContext(TraversalContext)
+  const Ctx = useTraversal()
   const { type } = props
   const { getForm } = Ctx.registry
 

--- a/src/guillo-gmi/actions/copy_items.js
+++ b/src/guillo-gmi/actions/copy_items.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { PathTree } from '../components/modal'
-import { useContext } from 'react'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 
 const withError = (res) => res.status >= 300
 
@@ -16,7 +15,7 @@ function getNewId(id = '') {
 }
 
 export function CopyItems(props) {
-  const Ctx = useContext(TraversalContext)
+  const Ctx = useTraversal()
   const { items = [] } = props
 
   async function copyItems(path, form) {

--- a/src/guillo-gmi/actions/move_items.js
+++ b/src/guillo-gmi/actions/move_items.js
@@ -1,12 +1,11 @@
 import React from 'react'
 import { PathTree } from '../components/modal'
-import { useContext } from 'react'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 
 const withError = (res) => res.status >= 300
 
 export function MoveItems(props) {
-  const Ctx = useContext(TraversalContext)
+  const Ctx = useTraversal()
   const { items = [] } = props
 
   async function moveItems(path) {

--- a/src/guillo-gmi/actions/remove_items.js
+++ b/src/guillo-gmi/actions/remove_items.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Confirm } from '../components/modal'
-import { useContext } from 'react'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 import { sleep } from '../lib/helpers'
 import { useConfig } from '../hooks/useConfig'
 
@@ -14,7 +13,7 @@ const getId = (item) => {
 }
 
 export function RemoveItems(props) {
-  const Ctx = useContext(TraversalContext)
+  const Ctx = useTraversal()
   const cfg = useConfig()
   const [loading, setLoading] = React.useState(false)
   const { items = [] } = props

--- a/src/guillo-gmi/components/behavior_view.js
+++ b/src/guillo-gmi/components/behavior_view.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { Table } from './ui/table'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 
 export function BehaviorsView({ context }) {
-  const Ctx = React.useContext(TraversalContext)
+  const Ctx = useTraversal()
   const { getBehavior } = Ctx.registry
 
   const behaviors = [].concat(

--- a/src/guillo-gmi/components/behaviors/iattachment.js
+++ b/src/guillo-gmi/components/behaviors/iattachment.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import { TraversalContext } from '../../contexts'
+import { useTraversal } from '../../contexts'
 import { FileUpload } from '../input/upload'
 import { Button } from '../input/button'
 
 export function IAttachment(props) {
-  const ctx = React.useContext(TraversalContext)
+  const ctx = useTraversal()
   const canModify = ctx.hasPerm('guillotina.ModifyContent')
 
   const uploadFile = async (file) => {

--- a/src/guillo-gmi/components/behaviors/idublincore.js
+++ b/src/guillo-gmi/components/behaviors/idublincore.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { Icon } from '../ui/icon'
 import { RenderField } from '../fields/renderField'
-import { TraversalContext } from '../../contexts'
+import { useTraversal } from '../../contexts'
 import { EditableField } from '../fields/editableField'
 import { Textarea } from '../input/textarea'
 import { Input } from '../input/input'
@@ -15,7 +15,7 @@ const Schema = {
 }
 
 export function IDublinCore(props) {
-  const Ctx = React.useContext(TraversalContext)
+  const Ctx = useTraversal()
   const modifyContent = Ctx.hasPerm('guillotina.ModifyContent')
 
   return (

--- a/src/guillo-gmi/components/context_toolbar.js
+++ b/src/guillo-gmi/components/context_toolbar.js
@@ -1,12 +1,11 @@
 import React from 'react'
 import { useEffect } from 'react'
-import { useContext } from 'react'
 
 import Dropdown from './input/dropdown'
 import useSetState from '../hooks/useSetState'
 import { Button } from './input/button'
 import { Icon } from './ui/icon'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 import { useConfig } from '../hooks/useConfig'
 import { useLocation } from '../hooks/useLocation'
 
@@ -15,7 +14,7 @@ const initialState = { types: undefined }
 
 export function CreateButton(props) {
   const [state, setState] = useSetState(initialState)
-  const Ctx = useContext(TraversalContext)
+  const Ctx = useTraversal()
   const Config = useConfig()
   useEffect(() => {
     ;(async function anyNameFunction() {
@@ -63,7 +62,7 @@ export function CreateButton(props) {
 
 export function ContextToolbar({ AddButton, ...props }) {
   const [location, setLocation] = useLocation()
-  const ctx = React.useContext(TraversalContext)
+  const ctx = useTraversal()
   const ref = React.useRef(null)
 
   const searchText = location.get('q')

--- a/src/guillo-gmi/components/flash.js
+++ b/src/guillo-gmi/components/flash.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 import { Notification } from './ui/notification'
 import { Delete } from './ui/delete'
 
 export function Flash() {
-  const Ctx = React.useContext(TraversalContext)
+  const Ctx = useTraversal()
   const { flash } = Ctx.state
 
   if (!flash.message) return null

--- a/src/guillo-gmi/components/item.js
+++ b/src/guillo-gmi/components/item.js
@@ -1,14 +1,13 @@
 import React from 'react'
 
 import { ItemModel } from '../models'
-import { TraversalContext } from '../contexts'
-import { useContext } from 'react'
+import { useTraversal } from '../contexts'
 import { Icon } from './ui/icon'
 import { ItemCheckbox } from './selected_items_actions'
 import { Delete } from './ui'
 
 export function Item({ item, setPath, icon }) {
-  const Ctx = useContext(TraversalContext)
+  const Ctx = useTraversal()
   const link = () => Ctx.setPath(item.path)
   return (
     <tr>
@@ -25,7 +24,7 @@ const smallcss = {
 }
 
 export function RItem({ item, search, columns }) {
-  const traversal = useContext(TraversalContext)
+  const traversal = useTraversal()
   const model = new ItemModel(item, traversal.url, traversal.path)
   const link = () => traversal.setPath(model.path)
 

--- a/src/guillo-gmi/components/panel/addons.js
+++ b/src/guillo-gmi/components/panel/addons.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import { TraversalContext } from '../../contexts'
+import { useTraversal } from '../../contexts'
 import useAsync from '../../hooks/useAsync'
 
 // TODO: Refactor without useAsync... just crudContext
 export function PanelAddons(props) {
-  const Ctx = React.useContext(TraversalContext)
+  const Ctx = useTraversal()
   let [action, setAction] = React.useState(false)
 
   const installAddon = async (Ctx, key) => {

--- a/src/guillo-gmi/components/panel/items.js
+++ b/src/guillo-gmi/components/panel/items.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { useContext } from 'react'
 
 import useSetState from '../../hooks/useSetState'
 import {
@@ -10,7 +9,7 @@ import {
 import { Pagination } from '../pagination'
 import { RItem } from '../item'
 import { SearchLabels } from '../../components/searchLabels'
-import { TraversalContext } from '../../contexts'
+import { useTraversal } from '../../contexts'
 import { buildQs } from '../../lib/search'
 import { parser } from '../../lib/search'
 import { useConfig } from '../../hooks/useConfig'
@@ -28,7 +27,7 @@ export function PanelItems(props) {
   const [location, setLocation] = useLocation()
   const { PageSize } = useConfig()
 
-  const Ctx = useContext(TraversalContext)
+  const Ctx = useTraversal()
   const [state, setState] = useSetState(initialState)
   const { items, loading, total } = state
   const columns = Ctx.client.getItemsColumn(items, Ctx.path)

--- a/src/guillo-gmi/components/panel/permissions.js
+++ b/src/guillo-gmi/components/panel/permissions.js
@@ -7,7 +7,6 @@ import { PermissionRoleperm } from './permissions_roleperm'
 import { Select } from '../input/select'
 import { Sharing } from '../../models'
 import { Table } from '../ui/table'
-import { TraversalContext } from '../../contexts'
 import { useCrudContext } from '../../hooks/useCrudContext'
 
 export function PanelPermissions(props) {
@@ -137,7 +136,7 @@ const defaultOptions = [
 ]
 
 export function AddPermission({ refresh, reset }) {
-  const Ctx = React.useContext(TraversalContext)
+  const Ctx = useTraversal()
   const [state, setState] = useSetState(initial)
 
   React.useEffect(() => {

--- a/src/guillo-gmi/components/panel/properties.js
+++ b/src/guillo-gmi/components/panel/properties.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { TraversalContext } from '../../contexts'
 import { ItemModel } from '../../models'
 import { BehaviorsView } from '../behavior_view'
 import { Icon } from '../ui/icon'
@@ -13,7 +12,7 @@ const _showProperties = ['@id', '@name', '@uid', 'title']
 const _editable = ['title']
 
 export function PanelProperties(props) {
-  const Ctx = React.useContext(TraversalContext)
+  const Ctx = useTraversal()
   const modifyContent = Ctx.hasPerm('guillotina.ModifyContent')
   const cfg = useConfig()
 

--- a/src/guillo-gmi/components/path.js
+++ b/src/guillo-gmi/components/path.js
@@ -1,12 +1,11 @@
 import React from 'react'
-import { TraversalContext } from '../contexts'
-import { useContext } from 'react'
+import { useTraversal } from '../contexts'
 import { useLocation } from '../hooks/useLocation'
 
 /* eslint jsx-a11y/anchor-is-valid: "off" */
 
 export function Path(props) {
-  const ctx = useContext(TraversalContext)
+  const ctx = useTraversal()
   const [, navigate] = useLocation()
 
   let segments = ctx.path.replace(/\/$/, '').split('/')

--- a/src/guillo-gmi/components/properties_view.js
+++ b/src/guillo-gmi/components/properties_view.js
@@ -1,8 +1,8 @@
 import React from 'react'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 
 export function PropertiesButtonView(properties) {
-  const Ctx = React.useContext(TraversalContext)
+  const Ctx = useTraversal()
   const { getProperties } = Ctx.registry
 
   const Props = getProperties(Ctx.context['@type'])
@@ -15,7 +15,7 @@ export function PropertiesButtonView(properties) {
 }
 
 export function PropertiesView(props) {
-  const Ctx = React.useContext(TraversalContext)
+  const Ctx = useTraversal()
   const { getProperties } = Ctx.registry
   const Props = getProperties(Ctx.context['@type'])
 

--- a/src/guillo-gmi/components/selected_items_actions.js
+++ b/src/guillo-gmi/components/selected_items_actions.js
@@ -1,7 +1,7 @@
 import React, { createContext, useState, useContext } from 'react'
 import Dropdown from './input/dropdown'
 import { Checkbox } from './input/checkbox'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 
 const ItemsActionsCtx = createContext({})
 const actions = {
@@ -27,7 +27,7 @@ const actions = {
  * Ex: Delete, Move, Copy...
  */
 export function ItemsActionsProvider({ items, children }) {
-  const traversal = useContext(TraversalContext)
+  const traversal = useTraversal()
   const [selected, setSelected] = useState({})
 
   function onSelectAllItems(checked) {
@@ -108,7 +108,7 @@ export function ItemCheckbox({ item }) {
  * Dropdown to choose some action to apply to the selected items.
  */
 export function ItemsActionsDropdown() {
-  const traversal = useContext(TraversalContext)
+  const traversal = useTraversal()
   const { selected, onAction } = useContext(ItemsActionsCtx)
   const disabled = Object.values(selected).every((v) => !v)
   const options = Object.keys(actions).map((action) => ({

--- a/src/guillo-gmi/contexts/index.js
+++ b/src/guillo-gmi/contexts/index.js
@@ -85,3 +85,7 @@ export function TraversalProvider({ children, ...props }) {
     </TraversalContext.Provider>
   )
 }
+
+export function useTraversal() {
+  return React.useContext(TraversalContext)
+}

--- a/src/guillo-gmi/hooks/useCrudContext.js
+++ b/src/guillo-gmi/hooks/useCrudContext.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 import useSetState from './useSetState'
 
 const initial = {
@@ -86,7 +86,7 @@ const get = (state, setState, Ctx) => async (endpoint) => {
 }
 
 export function useCrudContext() {
-  const Ctx = React.useContext(TraversalContext)
+  const Ctx = useTraversal()
   const [state, setState] = useSetState(initial)
 
   return {

--- a/src/guillo-gmi/views/application.js
+++ b/src/guillo-gmi/views/application.js
@@ -4,9 +4,7 @@ import { Item } from '../components/item'
 import { ItemTitle } from '../components/item'
 import { Button } from '../components/input/button'
 import { useState } from 'react'
-import { useContext } from 'react'
-import { useRef } from 'react'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 import { Modal } from '../components/modal'
 import { Form } from '../components/input/form'
 import { Input } from '../components/input/input'
@@ -31,7 +29,7 @@ export function ApplicationCtx(props) {
 }
 
 export function DatabaseCtx({ state, client, ...props }) {
-  const Ctx = useContext(TraversalContext)
+  const Ctx = useTraversal()
   const { containers } = state.context
   const { path } = state
   return (
@@ -75,11 +73,10 @@ export function CreateContainer(props) {
 }
 
 function ModalAddContainer({ isActive, setActive }) {
-  const Ctx = useContext(TraversalContext)
+  const Ctx = useTraversal()
   const [isLoading, setLoading] = useState(false)
   const [idField, setId] = useState('')
   const [error, setError] = useState(undefined)
-  const traversal = useContext(TraversalContext)
 
   async function createContainer(ev) {
     setLoading(true)
@@ -95,7 +92,7 @@ function ModalAddContainer({ isActive, setActive }) {
         setId('')
         setLoading(false)
         setActive(false)
-        traversal.flash('Container created', 'primary')
+        Ctx.flash('Container created', 'primary')
       } else {
         setId('')
         setLoading(false)

--- a/src/guillo-gmi/views/container.js
+++ b/src/guillo-gmi/views/container.js
@@ -3,7 +3,7 @@ import { TabsPanel } from '../components/tabs'
 import { ContextToolbar } from '../components/context_toolbar'
 import { PanelItems } from '../components/panel/items'
 import { PanelAddons } from '../components/panel/addons'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 import { PanelNotImplemented } from './base'
 import { PanelPermissions } from '../components/panel/permissions'
 import { PanelBehaviors } from '../components/panel/behaviors'
@@ -28,7 +28,7 @@ const tabsPermissions = {
 }
 
 export function ContainerCtx(props) {
-  const ctx = React.useContext(TraversalContext)
+  const ctx = useTraversal()
   const calculated = ctx.filterTabs(tabs, tabsPermissions)
   return (
     <TabsPanel

--- a/src/guillo-gmi/views/folder.js
+++ b/src/guillo-gmi/views/folder.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { TabsPanel } from '../components/tabs'
 import { ContextToolbar } from '../components/context_toolbar'
 import { PanelItems } from '../components/panel/items'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 import { PanelProperties } from '../components/panel/properties'
 import { PanelPermissions } from '../components/panel/permissions'
 import { PanelBehaviors } from '../components/panel/behaviors'
@@ -25,7 +25,7 @@ const tabsPermissions = {
 }
 
 export function FolderCtx(props) {
-  const ctx = React.useContext(TraversalContext)
+  const ctx = useTraversal()
   const calculated = ctx.filterTabs(tabs, tabsPermissions)
 
   return (

--- a/src/guillo-gmi/views/groups.js
+++ b/src/guillo-gmi/views/groups.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { TabsPanel } from '../components/tabs'
 import { PanelItems } from '../components/panel/items'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 import { useCrudContext } from '../hooks/useCrudContext'
 import { Icon } from '../components/ui/icon'
 import { useEffect } from 'react'
@@ -15,7 +15,7 @@ const tabs = {
 }
 
 export function GroupToolbar(props) {
-  const Ctx = React.useContext(TraversalContext)
+  const Ctx = useTraversal()
 
   return (
     <button

--- a/src/guillo-gmi/views/item.js
+++ b/src/guillo-gmi/views/item.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { TabsPanel } from '../components/tabs'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 import { PanelPermissions } from '../components/panel/permissions'
 import { PanelBehaviors } from '../components/panel/behaviors'
 import { PanelProperties } from '../components/panel/properties'
@@ -18,7 +18,7 @@ const tabsPermissions = {
 }
 
 export function ItemCtx(props) {
-  const ctx = React.useContext(TraversalContext)
+  const ctx = useTraversal()
   const calculated = ctx.filterTabs(tabs, tabsPermissions)
 
   return <TabsPanel tabs={calculated} currentTab="Properties" {...props} />

--- a/src/guillo-gmi/views/users.js
+++ b/src/guillo-gmi/views/users.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { TabsPanel } from '../components/tabs'
 import { PanelItems } from '../components/panel/items'
-import { TraversalContext } from '../contexts'
+import { useTraversal } from '../contexts'
 import { UserForm } from '../forms/users'
 import { formatDate } from '../lib/utils'
 import { useCrudContext } from '../hooks/useCrudContext'
@@ -15,7 +15,7 @@ const tabs = {
 }
 
 export function UsersToolbar(props) {
-  const Ctx = React.useContext(TraversalContext)
+  const Ctx = useTraversal()
 
   return (
     <button


### PR DESCRIPTION
https://github.com/guillotinaweb/guillotina_react/issues/67

For backward-compatibility, I keep the `TraversalContext`, but it's better to consume the context directly with the `useTraversal` hook.