### PR TITLE
[Feat] Add actions panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+0.11.0
+------
+ - add actions panel in container folder and item types (#99)
+
+0.10.0
+------
+ - Improve build (#95)
+
+
+0.9.0
+------
+ - Isolate client (#91)
+ - Improvement fields (#90)
+
+
+0.8.0
+------
+
+- Replace react-use to own hooks (#82)
+- Add prettier (#83)
+- Add LICENSE and CONTRIBUTING.md (#86)
+- e2e test own project (#84)
+- Some fixes (#88)
+- CI run workflows (#89)
+
 0.7.1
 ------
 - e2e test own project

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.0",
+  "version": "0.11.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:guillotinaweb/guillotina_react.git"

--- a/src/guillo-gmi/actions/copy_item.js
+++ b/src/guillo-gmi/actions/copy_item.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import { PathTree } from '../components/modal'
+import { useTraversal } from '../contexts'
+import { useCrudContext } from '../hooks/useCrudContext'
+
+function getNewId(id = '') {
+  const suffix = '-copy-'
+  const rgx = new RegExp(`($|${suffix}\\d*)`)
+
+  return id.replace(rgx, (r) => {
+    const num = parseInt(r.replace(suffix, '') || '0')
+    return `${suffix}${num + 1}`
+  })
+}
+
+export function CopyItem(props) {
+  const Ctx = useTraversal()
+  const { post } = useCrudContext()
+  const { item } = props
+
+  async function copyItem(path, form) {
+    const input = form[1] || {}
+    const { isError, errorMessage } = await post(
+      {
+        destination: path,
+        new_id: input.value || getNewId(item['@name']),
+      },
+      '@duplicate'
+    )
+
+    if (!isError) {
+      Ctx.flash(`Field copied!`, 'success')
+    } else {
+      Ctx.flash(`Failed to copy item!: ${errorMessage}`, 'danger')
+    }
+    Ctx.refresh()
+    Ctx.cancelAction()
+  }
+
+  return (
+    <PathTree
+      title="Copy to..."
+      defaultPath={`/${item['parent']['@name']}`}
+      onConfirm={copyItem}
+      onCancel={() => Ctx.cancelAction()}
+    >
+      <React.Fragment>
+        <small style={{ display: 'block', marginTop: 20 }}>
+          {`New id for "${item['@name']}" copy`}
+        </small>
+        <input
+          type="text"
+          className="input"
+          defaultValue={getNewId(item['@name'])}
+        />
+      </React.Fragment>
+    </PathTree>
+  )
+}

--- a/src/guillo-gmi/actions/copy_item.js
+++ b/src/guillo-gmi/actions/copy_item.js
@@ -2,16 +2,7 @@ import React from 'react'
 import { PathTree } from '../components/modal'
 import { useTraversal } from '../contexts'
 import { useCrudContext } from '../hooks/useCrudContext'
-
-function getNewId(id = '') {
-  const suffix = '-copy-'
-  const rgx = new RegExp(`($|${suffix}\\d*)`)
-
-  return id.replace(rgx, (r) => {
-    const num = parseInt(r.replace(suffix, '') || '0')
-    return `${suffix}${num + 1}`
-  })
-}
+import { getNewId } from '../lib/utils'
 
 export function CopyItem(props) {
   const Ctx = useTraversal()

--- a/src/guillo-gmi/actions/copy_items.js
+++ b/src/guillo-gmi/actions/copy_items.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { PathTree } from '../components/modal'
 import { useTraversal } from '../contexts'
+import { getContainerFromPath } from '../lib/client'
 
 const withError = (res) => res.status >= 300
 
@@ -48,7 +49,7 @@ export function CopyItems(props) {
   return (
     <PathTree
       title="Copy to..."
-      defaultPath={Ctx.path}
+      defaultPath={`/${Ctx.path.split(getContainerFromPath(Ctx.path))[1]}`}
       onConfirm={copyItems}
       onCancel={() => Ctx.cancelAction()}
     >

--- a/src/guillo-gmi/actions/copy_items.js
+++ b/src/guillo-gmi/actions/copy_items.js
@@ -2,19 +2,9 @@ import React from 'react'
 import { PathTree } from '../components/modal'
 import { useTraversal } from '../contexts'
 import { getContainerFromPath } from '../lib/client'
+import { getNewId } from '../lib/utils'
 
 const withError = (res) => res.status >= 300
-
-function getNewId(id = '') {
-  const suffix = '-copy-'
-  const rgx = new RegExp(`($|${suffix}\\d*)`)
-
-  return id.replace(rgx, (r) => {
-    const num = parseInt(r.replace(suffix, '') || '0')
-    return `${suffix}${num + 1}`
-  })
-}
-
 export function CopyItems(props) {
   const Ctx = useTraversal()
   const { items = [] } = props

--- a/src/guillo-gmi/actions/move_item.js
+++ b/src/guillo-gmi/actions/move_item.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import { PathTree } from '../components/modal'
+import { useGuillotinaClient, useTraversal } from '../contexts'
+import { useCrudContext } from '../hooks/useCrudContext'
+import { useLocation } from '../hooks/useLocation'
+
+export function MoveItem(props) {
+  const Ctx = useTraversal()
+  const { post } = useCrudContext()
+  const [, navigate] = useLocation()
+  const client = useGuillotinaClient()
+  const { item } = props
+
+  async function moveItem(path) {
+    const { isError, errorMessage, result } = await post(
+      {
+        destination: path,
+        new_id: item['@name'],
+      },
+      '@move'
+    )
+
+    if (!isError) {
+      navigate({
+        path: `/${client.cleanPath(result['@url'])}/`,
+        tab: '',
+      })
+      Ctx.flash(`Field moved!`, 'success')
+    } else {
+      Ctx.flash(`Failed to move item!: ${errorMessage}`, 'danger')
+    }
+
+    Ctx.refresh()
+    Ctx.cancelAction()
+  }
+
+  return (
+    <PathTree
+      title="Move to..."
+      onConfirm={moveItem}
+      onCancel={() => Ctx.cancelAction()}
+    />
+  )
+}

--- a/src/guillo-gmi/actions/remove_item.js
+++ b/src/guillo-gmi/actions/remove_item.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Confirm } from '../components/modal'
+import { useGuillotinaClient, useTraversal } from '../contexts'
+import { useCrudContext } from '../hooks/useCrudContext'
+import { useLocation } from '../hooks/useLocation'
+
+export function RemoveItem(props) {
+  const Ctx = useTraversal()
+  const { del, loading } = useCrudContext()
+  const [, navigate] = useLocation()
+  const client = useGuillotinaClient()
+  const { item } = props
+
+  async function removeItem() {
+    const { isError, errorMessage } = await del()
+
+    if (!isError) {
+      navigate({
+        path: `/${client.cleanPath(item['parent']['@id'])}/`,
+        tab: '',
+      })
+      Ctx.flash(`Field removed!`, 'success')
+    } else {
+      Ctx.flash(`Failed to delete item!: ${errorMessage}`, 'danger')
+    }
+
+    Ctx.refresh()
+    Ctx.cancelAction()
+  }
+
+  return (
+    <Confirm
+      loading={loading}
+      onCancel={() => Ctx.cancelAction()}
+      onConfirm={removeItem}
+      message={`Are you sure to remove: ${item['@name']}?`}
+    />
+  )
+}

--- a/src/guillo-gmi/components/panel/actions.js
+++ b/src/guillo-gmi/components/panel/actions.js
@@ -1,0 +1,54 @@
+import * as React from 'react'
+import { useTraversal } from '../../contexts'
+
+export const ACTIONS_OBJECT = {
+  DELETE: {
+    text: 'Delete',
+    perms: ['guillotina.DeleteContent'],
+    action: 'removeItem',
+  },
+  MOVE: {
+    text: 'Move to...',
+    perms: ['guillotina.MoveContent'],
+    action: 'moveItem',
+  },
+  COPY: {
+    text: 'Copy to...',
+    perms: ['guillotina.DuplicateContent'],
+    action: 'copyItem',
+  },
+}
+
+export function PanelActions() {
+  const traversal = useTraversal()
+
+  const hasPerm = (perms) => {
+    return perms.some((perm) => traversal.hasPerm(perm))
+  }
+
+  const onAction = (actionKey) => {
+    traversal.doAction(ACTIONS_OBJECT[actionKey].action, {
+      item: traversal.context,
+    })
+  }
+
+  return (
+    <React.Fragment>
+      {Object.keys(ACTIONS_OBJECT).map((actionKey) => {
+        if (hasPerm(ACTIONS_OBJECT[actionKey].perms)) {
+          return (
+            <button
+              key={`panel_action_${ACTIONS_OBJECT[actionKey].text}`}
+              className="button mr-4"
+              onClick={() => {
+                onAction(actionKey)
+              }}
+            >
+              {ACTIONS_OBJECT[actionKey].text}
+            </button>
+          )
+        }
+      })}
+    </React.Fragment>
+  )
+}

--- a/src/guillo-gmi/components/selected_items_actions.js
+++ b/src/guillo-gmi/components/selected_items_actions.js
@@ -4,7 +4,8 @@ import { Checkbox } from './input/checkbox'
 import { useTraversal } from '../contexts'
 
 const ItemsActionsCtx = createContext({})
-const actions = {
+
+export const actions = {
   DELETE: {
     text: 'Delete',
     perms: ['guillotina.DeleteContent'],

--- a/src/guillo-gmi/hooks/useRegistry.js
+++ b/src/guillo-gmi/hooks/useRegistry.js
@@ -6,8 +6,11 @@ import { ContainerCtx } from '../views/container'
 import { UsersCtx } from '../views/users'
 import { UserCtx } from '../views/users'
 import { CopyItems } from '../actions/copy_items'
+import { CopyItem } from '../actions/copy_item'
 import { MoveItems } from '../actions/move_items'
+import { MoveItem } from '../actions/move_item'
 import { RemoveItems } from '../actions/remove_items'
+import { RemoveItem } from '../actions/remove_item'
 import { AddItem } from '../actions/add_item'
 import { BaseForm } from '../forms/base'
 import { UserForm } from '../forms/users'
@@ -41,8 +44,11 @@ let registry = {
   actions: {
     addItem: AddItem,
     copyItems: CopyItems,
+    copyItem: CopyItem,
     moveItems: MoveItems,
+    moveItem: MoveItem,
     removeItems: RemoveItems,
+    removeItem: RemoveItem,
   },
   forms: {
     UserManager: BaseForm,

--- a/src/guillo-gmi/lib/auth.js
+++ b/src/guillo-gmi/lib/auth.js
@@ -20,7 +20,7 @@ export class Auth {
   }
 
   async login(username, password) {
-    const url = this.getUrl('@login')
+    const url = this.getUrl('/db/container-test/@login')
     try {
       const data = await fetch(url, {
         method: 'post',

--- a/src/guillo-gmi/lib/auth.js
+++ b/src/guillo-gmi/lib/auth.js
@@ -20,7 +20,7 @@ export class Auth {
   }
 
   async login(username, password) {
-    const url = this.getUrl('/db/container-test/@login')
+    const url = this.getUrl('@login')
     try {
       const data = await fetch(url, {
         method: 'post',

--- a/src/guillo-gmi/lib/utils.js
+++ b/src/guillo-gmi/lib/utils.js
@@ -5,3 +5,13 @@ export const formatDate = (str) => {
     d.getMonth() + 1
   }/${d.getFullYear()} ${d.getHours()}:${minutes}`
 }
+
+export function getNewId(id = '') {
+  const suffix = '-copy-'
+  const rgx = new RegExp(`($|${suffix}\\d*)`)
+
+  return id.replace(rgx, (r) => {
+    const num = parseInt(r.replace(suffix, '') || '0')
+    return `${suffix}${num + 1}`
+  })
+}

--- a/src/guillo-gmi/views/container.js
+++ b/src/guillo-gmi/views/container.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { TabsPanel } from '../components/tabs'
 import { ContextToolbar } from '../components/context_toolbar'
 import { PanelItems } from '../components/panel/items'
+import { PanelActions } from '../components/panel/actions'
 import { PanelAddons } from '../components/panel/addons'
 import { useTraversal } from '../contexts'
 import { PanelNotImplemented } from './base'
@@ -15,6 +16,7 @@ const tabs = {
   Registry: PanelNotImplemented,
   Behaviors: PanelBehaviors,
   Permissions: PanelPermissions,
+  Actions: PanelActions,
   // Requester: PanelRequester
 }
 

--- a/src/guillo-gmi/views/folder.js
+++ b/src/guillo-gmi/views/folder.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { TabsPanel } from '../components/tabs'
 import { ContextToolbar } from '../components/context_toolbar'
 import { PanelItems } from '../components/panel/items'
+import { PanelActions } from '../components/panel/actions'
 import { useTraversal } from '../contexts'
 import { PanelProperties } from '../components/panel/properties'
 import { PanelPermissions } from '../components/panel/permissions'
@@ -13,6 +14,7 @@ const tabs = {
   Properties: PanelProperties,
   Behaviors: PanelBehaviors,
   Permissions: PanelPermissions,
+  Actions: PanelActions,
   // Requester: PanelRequester,
 }
 

--- a/src/guillo-gmi/views/item.js
+++ b/src/guillo-gmi/views/item.js
@@ -4,11 +4,13 @@ import { useTraversal } from '../contexts'
 import { PanelPermissions } from '../components/panel/permissions'
 import { PanelBehaviors } from '../components/panel/behaviors'
 import { PanelProperties } from '../components/panel/properties'
+import { PanelActions } from '../components/panel/actions'
 
 const tabs = {
   Properties: PanelProperties,
   Behaviors: PanelBehaviors,
   Permissions: PanelPermissions,
+  Actions: PanelActions,
 }
 
 const tabsPermissions = {


### PR DESCRIPTION
I have created an Actions panels for can move, copy or delete an object individually, for the moment we only can copy move or delete from the items list and in some cases the user don't have permissions in this folder, but he can permissions in the object.

I have tried to use the components that already exists to move, copy and delete multiple objects, but finnaly I have decided to create a new components, after each action we must do some differents actions. For example after move, navigate to new object, or after delete navigate to parent. Another reason is that item payload is different to search item payload to get info from object.
