### PR TITLE
e2e cypress retry failed tests

### DIFF
--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,4 +1,8 @@
 {
   "baseUrl": "http://localhost:3000?path=",
-  "experimentalFetchPolyfill": true
+  "experimentalFetchPolyfill": true,
+  "retries": {
+    "runMode": 2,
+    "openMode": 1
+  }
 }


### PR DESCRIPTION
This config addition allows cypress to retry a test if it fails. 