### PR TITLE
Fix microbundle bundle bug

### DIFF
--- a/src/guillo-gmi/components/context_toolbar.js
+++ b/src/guillo-gmi/components/context_toolbar.js
@@ -72,13 +72,14 @@ export function ContextToolbar({ AddButton, ...props }) {
   const searchText = location.get('q')
 
   useEffect(() => {
-    ;(async () => {
-      const types = await traversal.client.getTypes(traversal.path)
-      setState({
-        types: types.filter((item) => !Config.DisabledTypes.includes(item)),
-      })
-    })()
+    loadTypes()
   }, [traversal.path])
+  async function loadTypes() {
+    const types = await traversal.client.getTypes(traversal.path)
+    setState({
+      types: types.filter((item) => !Config.DisabledTypes.includes(item)),
+    })
+  }
 
   const onSearchQuery = (ev) => {
     const search = ev.target[0].value


### PR DESCRIPTION
Is the same issue that this one: https://github.com/guillotinaweb/guillotina_react/pull/63 but in another place.

Microbundle transpile this:

```js
React.useEffect(() => {
    (async () => {	
      await something();	
    })();	
  }, []);
```

to

```js
React.useEffect(function () {
    try {
      return Promise.resolve(something()).then(function () {});
    } catch (e) {
      Promise.reject(e);
    }
  }, []);
```

And returning a promise to `useEffect` , causes an error:

![image](https://user-images.githubusercontent.com/13313058/110625454-b9af7900-819f-11eb-9e01-e2faaa1c04dd.png)


After debugging where the error was coming from, I have seen that this happened again...

We have to avoid writing self-called async functions to avoid this bug with microbundle in the future.

